### PR TITLE
handleCallEvent: reduced log severity to info

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sipgate/integration-bridge",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sipgate/integration-bridge",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "license": "UNLICENSED",
       "dependencies": {
         "ajv": "^8.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sipgate/integration-bridge",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "sipgate Integration Bridge Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/models/controller.model.ts
+++ b/src/models/controller.model.ts
@@ -15,7 +15,7 @@ import {
 } from ".";
 import { calendarEventsSchema, contactsSchema } from "../schemas";
 import { shouldSkipCallEvent } from "../util/call-event.util";
-import { errorLogger, infoLogger, warnLogger } from "../util/logger.util";
+import { errorLogger, infoLogger } from "../util/logger.util";
 import { parsePhoneNumber } from "../util/phone-number-utils";
 import { validate } from "../util/validate";
 import { APIContact } from "./api-contact.model";

--- a/src/models/controller.model.ts
+++ b/src/models/controller.model.ts
@@ -632,7 +632,7 @@ export class Controller {
           providerConfig.apiKey
         );
       else
-        warnLogger(
+        infoLogger(
           "handleCallEvent",
           `Did not create callEvent`,
           providerConfig.apiKey


### PR DESCRIPTION
Wenn `handleCallEvent` kein Event erzeugen konnte wird die zugehörige Message bisher mit log severity warning gelogt. Blöderweise wird das im google cloud log dann als log severity Error gespeichert. Daher mein Vorschlag, das mit Stufo info zu loggen, um nicht regelmäßig den Alarm zu triggern. Alternativ müsste man die gcloud library einbinden fürs logging, um alle log Stufen korrekt zu übermitteln.   