### PR TITLE
Include 5 characters long numbers as direct dial

### DIFF
--- a/src/util/phone-number-utils.ts
+++ b/src/util/phone-number-utils.ts
@@ -46,5 +46,5 @@ export const parsePhoneNumber = (
 };
 
 export const isDirectDial = (phoneNumber: string) => {
-  return phoneNumber.length < MIN_PHONE_NUMBER_LENGTH;
+  return phoneNumber.length <= MIN_PHONE_NUMBER_LENGTH;
 };


### PR DESCRIPTION
Wenn man Nummern wie "10000" oder "10005" als Kontakt anlegt dann werden diese falsch geparst und es kommt +491000 raus ✌🏼 
gibt es einen Grund warum ihr die 5 stellige Nummern als normale Nummern parst?